### PR TITLE
remove the svn dependency and install wp unit test packages via git

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,6 @@ jobs:
                 command: sudo apt-get update
 
             - run:
-                name: "Install svn for WordPress"
-                command: sudo apt-get install subversion
-
-            - run:
                 name: "Install MariaDB"
                 command: |
                     sudo apt-get install mariadb-server
@@ -32,6 +28,11 @@ jobs:
                 command: |
                     sudo wget -O /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-5.7.27.phar
                     sudo chmod +x /usr/local/bin/phpunit
+            - run:
+                name: "Check out WP PHP Unit libraries"
+                command: |
+                    mkdir ~/wordpress-dev && mkdir ~/wordpress-dev/tests && mkdir ~/wordpress-dev/tests/phpunit
+                    git clone https://github.com/wp-phpunit/wp-phpunit.git ~/wordpress-dev/tests/phpunit
 
             # Check out the code.
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,8 @@ jobs:
             - run:
                 name: "Check out WP PHP Unit libraries"
                 command: |
-                    mkdir ~/wordpress-dev && mkdir ~/wordpress-dev/tests && mkdir ~/wordpress-dev/tests/phpunit
-                    git clone https://github.com/wp-phpunit/wp-phpunit.git ~/wordpress-dev/tests/phpunit
+                    mkdir /tmp/wordpress-tests-lib
+                    git clone https://github.com/wp-phpunit/wp-phpunit.git /tmp/wordpress-tests-lib
 
             # Check out the code.
             - checkout

--- a/tests/class-test-api.php
+++ b/tests/class-test-api.php
@@ -202,6 +202,7 @@ class Test_API extends \WP_UnitTestCase {
 	 */
 	public function test_maybe_humanize_time() {
 		$now        = current_time( 'U' );
+		$one_minute = $now - MINUTE_IN_SECONDS;
 		$yesterday  = $now - DAY_IN_SECONDS;
 		$two_weeks  = $now - ( 2 * WEEK_IN_SECONDS );
 		$a_month    = $now - MONTH_IN_SECONDS;
@@ -211,8 +212,13 @@ class Test_API extends \WP_UnitTestCase {
 		 * All of these tests will make sure the humanized time is used.
 		 */
 		$this->assertEquals(
-			'1 min ago',
+			'1 second ago',
 			maybe_humanize_time( $now )
+		);
+
+		$this->assertEquals(
+			'1 min ago',
+			maybe_humanize_time( $one_minute )
 		);
 
 		$this->assertEquals(


### PR DESCRIPTION
This should solve the current issue with Circle builds failing due to the WordPress unit test setup script failing.

* removes svn install
* adds git clone to https://github.com/wp-phpunit/wp-phpunit for unit test libs
* fixes unit test that was failing

We might want to remove the 1 second test entirely in case the environment took longer to run it for some reason. Leaving it for now because this was the original test that was failing for `1 second ago` not matching expected `1 minute ago`.