### PR TITLE
Fix the config loading logic

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -19,14 +19,24 @@ const JUICER_ENDPOINT = 'https://www.juicer.io/api/feeds/';
  * Kick everything off.
  */
 function bootstrap() {
+	$has_config = false;
+
+	// If the Juicer constants are defined...
 	if (
-		// If none of the Juicer constants are defined...
-		! defined( 'JUICER_ID' ) ||
-		! defined( 'JUICER_SHORT_URL' ) ||
-		! defined( 'JUICER_LONG_URL' ) ||
-		! defined( 'JUICER_SITE_NAME' ) ||
-		! has_altis_config()
+		defined( 'JUICER_ID' ) &&
+		defined( 'JUICER_SHORT_URL' ) &&
+		defined( 'JUICER_LONG_URL' ) &&
+		defined( 'JUICER_SITE_NAME' )
 	) {
+		$has_config = true;
+	}
+
+	// If the Altis config is in place...
+	if ( function_exists( 'Altis\\get_config' ) && has_altis_config() ) {
+		$has_config = true;
+	}
+
+	if ( ! $has_config ) {
 		// ...load the settings page.
 		require_once __DIR__ . '/settings.php';
 		Settings\bootstrap();


### PR DESCRIPTION
The problem with the logic that determines if there's config in place is that the condition will almost always evaluate to true and cause the settings page to load even when it shouldn't be.

```php
if (
    // If none of the Juicer constants are defined...
    ! defined( 'JUICER_ID' ) ||
    ! defined( 'JUICER_SHORT_URL' ) ||
    ! defined( 'JUICER_LONG_URL' ) ||
    ! defined( 'JUICER_SITE_NAME' ) ||
    ! has_altis_config()
) {
```

The only way for this condition to evaluate to false is if all of the constants are defined *and* Altis is in use *and* there's Juicer config in place in Altis. This won't happen because you either use the constants or you use Altis config, you wouldn't use both.

Currently on a site with just the constants defined this condition still evaluates to true and loads the Settings screen because Altis isn't in use so the whole condition evaluates to true.

This change alters the logic so either the constants can be used, or the Altis config can be used if Altis is in use.